### PR TITLE
Change sklearn to scikit-learn

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 numpy
 tqdm
-sklearn
+scikit-learn

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     install_requires=[
 		'numpy',
 		'tqdm',
-		'sklearn',
+		'scikit-learn',
     ],
 	python_requires='>=3.4, <4',
 	classifiers=[


### PR DESCRIPTION
Please assign an appropriate label to the PR:
- bug : Cannot install sklearn because it's deprecated. Use scikit-learn instead.
- documentation : -
- enhancement : -
- release : This PR is a release PR to the `release` branch.

**What does this implement/fix? Explain your changes.**

Just change scklearn to scikit-learn

**Closing issues**

Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
